### PR TITLE
Upgrade to 5.0.d Alfresco version

### DIFF
--- a/src/main/amp/config/alfresco/web-extension/site-data/extensions/alfresco-inboxes.xml
+++ b/src/main/amp/config/alfresco/web-extension/site-data/extensions/alfresco-inboxes.xml
@@ -2,7 +2,7 @@
     <modules>
         <module>
             <id>alfresco-inboxes</id>
-            <version>1.0</version>
+            <version>${noSnapshotVersion}</version>
             <auto-deploy>true</auto-deploy>
             <configurations>
                 <config evaluator="string-compare" condition="WebFramework"

--- a/src/main/amp/config/alfresco/web-extension/site-webscripts/softwareloop/inboxes/inboxes.get.config.xml
+++ b/src/main/amp/config/alfresco/web-extension/site-webscripts/softwareloop/inboxes/inboxes.get.config.xml
@@ -1,14 +1,12 @@
 <inboxes>
-    <group id="my-documents">
+    <group id="my-documents" enabledGroup="GROUP_EMAIL_CONTRIBUTORS,GROUP_ALFRESCO_ADMINISTRATORS">
         <inbox id="drafts" iconClass="foundicon-paper-clip">
             <query><![CDATA[
-            SELECT d.*, t.* 
-            FROM cmis:document AS d
-            JOIN cm:titled AS t on d.cmis:objectId = t.cmis:objectId
-            WHERE contains(d, 'PATH:"/app:company_home/st:sites/cm:swsdp/cm:documentLibrary/cm:Meeting_x0020_Notes/*"')
+            SELECT d.*, t.* FROM cmis:document AS d JOIN cm:titled AS t on d.cmis:objectId = t.cmis:objectId
+             WHERE contains(d, 'PATH:"/app:company_home/st:sites/cm:swsdp/cm:documentLibrary/cm:Meeting_x0020_Notes/*"')
             ]]></query>
         </inbox>
-        <inbox id="for-my-approval" iconClass="foundicon-inbox">
+      <inbox id="for-my-approval" iconClass="foundicon-inbox">
             <query><![CDATA[
             SELECT d.*, t.*
             FROM cmis:document AS d
@@ -33,7 +31,7 @@
             ]]></query>
         </inbox>
     </group>
-    <group id="archive">
+    <group id="archive" enabledUser="admin">
         <inbox id="invoices" iconClass="foundicon-page">
             <query><![CDATA[
             SELECT d.*, t.*
@@ -41,7 +39,7 @@
             JOIN cm:titled AS t on d.cmis:objectId = t.cmis:objectId
             WHERE d.cmis:objectTypeId='cmis:document'
             AND d.cmis:createdBy = 'mjackson'
-            ]]></query>
+             ]]></query>
         </inbox>
         <inbox id="purchase-orders" iconClass="foundicon-left-arrow">
             <query><![CDATA[

--- a/src/main/amp/config/alfresco/web-extension/site-webscripts/softwareloop/inboxes/inboxes.get.js
+++ b/src/main/amp/config/alfresco/web-extension/site-webscripts/softwareloop/inboxes/inboxes.get.js
@@ -20,6 +20,9 @@ var groups = webscriptConfig.group;
 var group;
 var index;
 var index2;
+var indexGroup;
+var indexGroup2;
+var indexUser;
 var groupInboxes;
 var groupInbox;
 var groupInboxName;
@@ -31,33 +34,128 @@ for (index in groups) {
         name: "softwareloop/inboxes/Group",
         config: {
             id: String(group.@id),
+			enabledGroup: String(group.@enabledGroup),//attribute to manage group visibility 
+ 			enabledUser: String(group.@enabledUser),//attribute to manage user visibility
             widgets: []
         }
     };
-    inboxes.config.widgets.push(groupWidget);
-    groupInboxes = group.inbox;
-    for (index2 in groupInboxes) {
-        groupInbox = groupInboxes[index2];
-        groupInboxName = String(groupInbox.@inboxClass);
-        if (!groupInboxName) {
-            groupInboxName = defaultInboxClass;
-        }
-        inboxWidget = {
-            name: groupInboxName,
-            config: {
-                id: String(groupInbox.@id),
-                iconClass: String(groupInbox.@iconClass),
-                query: String(groupInbox.query),
-                weekStartOffset: weekStartOffset
-            }
-        };
-        var itemClass = String(groupInbox.@itemClass);
-        if (itemClass) {
-            inboxWidget.config.itemClass = itemClass;
-        }
-        groupWidget.config.widgets.push(inboxWidget);
-    }
-}
+
+
+      var actionUrl =  "/api/people/"+user.name+"?groups=true";
+	  
+	  var json = remote.call(actionUrl);
+
+	  if (json.status == 200)   {
+
+         var proprieta = eval('(' + json + ')');
+ 	     var gruppi = proprieta.groups;
+						 
+					 
+		//groups list, with separator ',' 
+		var gruppoAbil = groupWidget.config.enabledGroup;
+		//users list, with separator ',' 
+		var uteAbil = groupWidget.config.enabledUser;
+		var found = false;
+		if(!gruppoAbil && !uteAbil){//if groups and users not present everyone can see all menu items
+			inboxes.config.widgets.push(groupWidget);
+			groupInboxes = group.inbox;
+			for (index2 in groupInboxes) {
+				groupInbox = groupInboxes[index2];
+				groupInboxName = String(groupInbox.@inboxClass);
+				if (!groupInboxName) {
+					groupInboxName = defaultInboxClass;
+				}
+				inboxWidget = {
+					name: groupInboxName,
+					config: {
+						id: String(groupInbox.@id),
+						iconClass: String(groupInbox.@iconClass),
+						query: String(groupInbox.query),
+						weekStartOffset: weekStartOffset
+					}
+				};
+				var itemClass = String(groupInbox.@itemClass);
+				if (itemClass) {
+					inboxWidget.config.itemClass = itemClass;
+				}
+				groupWidget.config.widgets.push(inboxWidget);
+			}
+		}
+		else{ //presence of users or groups
+			if(gruppoAbil){//groups
+				var gruppiAbil = gruppoAbil.split(",");
+				for(indexGroup2 in gruppiAbil){
+					var g2 = gruppiAbil[indexGroup2];
+					for (indexGroup in gruppi) {//read logged user groups
+						var g = gruppi[indexGroup].itemName;
+						if(groupWidget.config.enabledGroup && g==g2){
+							inboxes.config.widgets.push(groupWidget);
+							groupInboxes = group.inbox;
+							for (index2 in groupInboxes) {
+								groupInbox = groupInboxes[index2];
+								groupInboxName = String(groupInbox.@inboxClass);
+								if (!groupInboxName) {
+									groupInboxName = defaultInboxClass;
+								}
+								inboxWidget = {
+									name: groupInboxName,
+									config: {
+										id: String(groupInbox.@id),
+										iconClass: String(groupInbox.@iconClass),
+										query: String(groupInbox.query),
+										weekStartOffset: weekStartOffset
+									}
+								};
+								var itemClass = String(groupInbox.@itemClass);
+								if (itemClass) {
+									inboxWidget.config.itemClass = itemClass;
+								}
+								groupWidget.config.widgets.push(inboxWidget);
+							}
+							found = true;
+							break;
+						}
+					}
+					if(found) break;
+				}
+			}
+			if(!found && uteAbil){//users (and not yet visibile)
+				var utentiAbil = groupWidget.config.enabledUser.split(",");
+				for(indexUser in utentiAbil){
+					var u = utentiAbil[indexUser];
+					if(u == user.name){
+						found = true;
+						inboxes.config.widgets.push(groupWidget);
+						groupInboxes = group.inbox;
+						for (index2 in groupInboxes) {
+							groupInbox = groupInboxes[index2];
+							groupInboxName = String(groupInbox.@inboxClass);
+							if (!groupInboxName) {
+								groupInboxName = defaultInboxClass;
+							}
+							inboxWidget = {
+								name: groupInboxName,
+								config: {
+									id: String(groupInbox.@id),
+									iconClass: String(groupInbox.@iconClass),
+									query: String(groupInbox.query),
+									weekStartOffset: weekStartOffset
+								}
+							};
+							var itemClass = String(groupInbox.@itemClass);
+							if (itemClass) {
+								inboxWidget.config.itemClass = itemClass;
+							}
+							groupWidget.config.widgets.push(inboxWidget);
+						}
+					}
+					if(found) break;
+				}
+			}
+		 }
+	  }
+   }
+	
 
 var results = {
     name: "alfresco/layout/VerticalWidgets",
@@ -83,6 +181,12 @@ model.jsonModel = {
             config: {
                 baseClass: "side-margins",
                 widgets: [
+                    {
+                        name: "alfresco/html/Spacer",
+                        config: {
+                            height: "14px"
+                        }
+                    },
                     {
                         name: "alfresco/layout/HorizontalWidgets",
                         config: {

--- a/src/main/amp/web/js/softwareloop/cmis/Entry.js
+++ b/src/main/amp/web/js/softwareloop/cmis/Entry.js
@@ -6,7 +6,6 @@ define([
 ], function (declare, array, cmis, browser) {
     return declare(null, {
         constructor: function (entryNode) {
-            this.id = entryNode.getElementsByTagName("id")[0].firstChild.nodeValue.substring(9);
             this.attributes = {};
             this.parseProperties(entryNode, "propertyId",
                 function (stringValue) {
@@ -26,6 +25,8 @@ define([
                 }
             );
             this.parseProperties(entryNode, "propertyDateTime", cmis.parseDate);
+
+            this.id = this.getAttributeValues("cmis:versionSeriesId");
         },
 
         parseProperties: function (entryNode, tagName, converter) {

--- a/src/main/amp/web/js/softwareloop/cmis/cmis.js
+++ b/src/main/amp/web/js/softwareloop/cmis/cmis.js
@@ -4,7 +4,7 @@ define([
     "dojo/request/xhr",
     "softwareloop/util/XmlBuffer"
 ], function (array, locale, xhr, XmlBuffer) {
-    var datePattern = "yyyy-MM-dd'T'HH:mm:ss.SSSZ";
+    var datePattern = "yyyy-MM-dd'T'HH:mm:ss.SZ";
 
     var formatOptions = {
         datePattern: datePattern,

--- a/src/main/amp/web/js/softwareloop/inboxes/Inbox.js
+++ b/src/main/amp/web/js/softwareloop/inboxes/Inbox.js
@@ -56,7 +56,7 @@ define([
 
         postCreate: function () {
             this.inherited(arguments);
-            var url = Alfresco.constants.PROXY_URI + "cmis/query";
+            var url = "/share/proxy/alfresco-api/-default-/public/cmis/versions/1.1/atom/query";
             xhr(url, {
                 handleAs: "xml",
                 query: this.getCmisQueryObject()
@@ -74,7 +74,7 @@ define([
             return {
                 q: cmisQuery,
                 includeAllowableActions: false,
-                includeRelationships: false,
+                //includeRelationships: false, // breaks 5.0.b
                 searchAllVersions: false,
                 skipCount: 0
             };
@@ -111,7 +111,7 @@ define([
 
         handleData: function (data) {
             var totalResultsNodes =
-                browser.getElementsByTagName(data, "opensearch", "totalResults");
+                browser.getElementsByTagName(data, "cmisra", "numItems");
             var totalResults = totalResultsNodes[0].firstChild.nodeValue;
             this.counterNode.innerHTML = totalResults;
 
@@ -124,7 +124,7 @@ define([
                 try {
                     var i;
                     var items = [];
-                    var entryNodes = this.data.getElementsByTagName("entry");
+                    var entryNodes = browser.getElementsByTagName(this.data, "atom", "entry");
                     array.forEach(entryNodes, function (entryNode) {
                         var entry = new Entry(entryNode);
                         var item = new itemClass({entry: entry});

--- a/src/main/amp/web/js/softwareloop/inboxes/templates/Test.html
+++ b/src/main/amp/web/js/softwareloop/inboxes/templates/Test.html
@@ -1,0 +1,31 @@
+<div class="inboxes-item">
+    <div class="inbox-item-icon"><img src="${previewUrl}"></div>
+    <div class="inbox-item-description">
+        <div class="inboxes-item-line1">
+            <div class="inboxes-item-float-right inboxes-item-show-on-hover">
+                <button class="inboxes-item-button inboxes-item-button-approve"
+                        data-dojo-attach-event="click:approveAction">${approveLabel}
+                </button>
+                <button class="inboxes-item-button inboxes-item-button-reject"
+                        data-dojo-attach-event="click:rejectAction">${rejectLabel}
+                </button>
+            </div>
+            <h2>
+                ${escapedLine1}
+                <span class="inboxes-item-tag">${escapedTag}</span>
+            </h2>
+        </div>
+        <div class="inboxes-item-line2">
+            <h3>${escapedLine2}</h3>
+        </div>
+        <div class="inboxes-item-line3">
+            <div class="inboxes-item-float-right inboxes-item-show-on-hover">
+                <a class="download-link" href="${downloadUrl}">${downloadLabel}</a>
+            </div>
+            ${escapedLine3}
+        </div>
+        <div class="inboxes-item-line4">
+            ${escapedLine4}
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
Upgrade to 5.0.d Alfresco version and added groups and users visibility.

The released is tested against a Community 5.0.d clean installation.
#### NEW FEATURE:
- Groups and Users Visibility.
Manage user and group visibility by adding tag `enabledGroup` and `enabledUser` to an inboxes group in the configuration file: `inboxes.get.config.xml` 
Tags can contain list of groups/users separeted by ','.

For example:
```
<group id="my-documents" enabledGroup="GROUP_EMAIL_CONTRIBUTORS,GROUP_ALFRESCO_ADMINISTRATORS">
<group id="archive" enabledUser="admin">

```
If tags are not present, the item will be visible to everyone.
For more example you can look at the config file commited in this branch.
